### PR TITLE
fix(carousel-infinite): breaks on minification, needed [array] notation

### DIFF
--- a/src/directives/rn-carousel-infinite.js
+++ b/src/directives/rn-carousel-infinite.js
@@ -1,6 +1,6 @@
 angular.module('angular-carousel')
 
-.directive('rnCarouselInfinite', function($parse, $compile) {
+.directive('rnCarouselInfinite', ['$parse', '$compile', function($parse, $compile) {
   return {
     restrict: 'EA',
     transclude:  true,
@@ -20,4 +20,4 @@ angular.module('angular-carousel')
       };
     }
   };
-});
+}]);


### PR DESCRIPTION
Hi, your infinite carousel directive was breaking on minification as per this:

http://building.getbrandid.com/2013/03/22/your-angular-js-directives-will-break-when-minified-this-is-how-you-write-directives-likeaboss/

Was a small fix
