### PR TITLE
Possible bug in CollectionManager.length

### DIFF
--- a/src/services/CollectionManager.js
+++ b/src/services/CollectionManager.js
@@ -150,7 +150,7 @@ angular.module('angular-carousel')
             this.index=0;
             this.position=0;
         }
-        this.items = items;
+        this.items = items || [];  // prevent internal errors when items is undefined
         this.init();
     };
     CollectionManager.prototype.cycleAtEnd = function() {


### PR DESCRIPTION
If ng-repeat expression evaluates is a empty list the $watch inside the directives passes undefined to CollecitonManager.setItems which breaks CollectionManager.length
