### PR TITLE
Round offset position to avoid antialiasing problem

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -227,7 +227,7 @@ angular.module('angular-carousel')
         window.addEventListener('orientationchange', resize);
         // when window is resized (responsive design)
         window.addEventListener('resize', resize);
-          
+
         function resize () {
             updateContainerWidth();
             updateSlidePosition();
@@ -256,7 +256,7 @@ angular.module('angular-carousel')
           /* trigger carousel position update */
           skipAnimation = !!forceSkipAnimation || skipAnimation;
           if (containerWidth===0) updateContainerWidth();
-          offset = scope.carouselCollection.getRelativeIndex() * -containerWidth;
+          offset = Math.round(scope.carouselCollection.getRelativeIndex() * -containerWidth);
           if (skipAnimation===true) {
               carousel.removeClass('rn-carousel-animate')
                   .addClass('rn-carousel-noanimate')


### PR DESCRIPTION
When the position is a rounded number, some browser doesn't render the
text correctly. Rounding the offset solve the problem.
