### PR TITLE
added ability to specify swipeless click fn, might be workaround for #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `prev()` and `next()` function return promises containing the prev and next 
  - `rn-carousel-buffered` to buffer the carousel, good to minimize the DOM.
  - ~~`rn-carousel-cycle` to have an forever-cycling carousel.~~ (BROKEN)
  - `rn-carousel-watch` force deep watch of the ngRepeat collection (listen to add/remove items).
-
+ - `rn-carousel-click` specify a callback function when a slide is clicked but not swiped; function should take the current item as its argument.
 
 ### Infinite carousel :
 

--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -305,6 +305,18 @@ angular.module('angular-carousel')
             swiping = 0;
         }
 
+        function swipelessClick() {
+          if (angular.isDefined(iAttrs.rnCarouselClick)) {
+            scope.$apply(function() {
+              var clickCallback = $parse(iAttrs.rnCarouselClick)(scope);
+              if (clickCallback) {
+                var currentItem = scope.carouselCollection.cards[scope.carouselCollection.position];
+                clickCallback(currentItem);
+              }
+            });
+          }
+        }
+                          
         function documentMouseUpEvent(event) {
           swipeEnd({
             x: event.clientX,
@@ -351,6 +363,7 @@ angular.module('angular-carousel')
             }
           },
           end: function (coords) {
+            if (swiping === 1) swipelessClick();
             swipeEnd(coords);
           }
         });


### PR DESCRIPTION
As discussed in #27, swipe interferes with the normal click events. This adds an option to the directive to specify a callback function for swipeless clicks.
