### PR TITLE
[fix #70] Convert calculated width to integer to prevent display rounding errors

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -242,6 +242,7 @@ angular.module('angular-carousel')
             } else {
               containerWidth = slides[0].getBoundingClientRect().width;
             }
+            containerWidth = Math.floor(containerWidth);
             container.css('width', containerWidth + 'px');
             return containerWidth;
         }


### PR DESCRIPTION
In reference to issue #70
