### PR TITLE
Prevent slide range overrun by checking the slide boundary.

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -304,8 +304,15 @@
                             currentOffset = (scope.carouselIndex * containerWidth),
                             absMove = currentOffset - destination,
                             slidesMove = -Math[absMove>=0?'ceil':'floor'](absMove / containerWidth),
-                            shouldMove = Math.abs(absMove) > minMove,
-                            moveOffset = shouldMove?slidesMove:0;
+                            shouldMove = Math.abs(absMove) > minMove;
+
+                        if ((slidesMove + scope.carouselIndex) >= slidesCount ) {
+                            slidesMove = slidesCount - 1 - scope.carouselIndex;
+                        }
+                        if ((slidesMove + scope.carouselIndex) < 0) {
+                            slidesMove = -scope.carouselIndex;
+                        }
+                        var moveOffset = shouldMove?slidesMove:0;
 
                         destination = (moveOffset + scope.carouselIndex) * containerWidth;
                         amplitude = destination - offset;


### PR DESCRIPTION
It is quite verbose, but it prevents the issue #85 as well as the bug that I could swipe to non-existing slide 2 when I had just two slides.

The original code didn't check the range and it could issue `scroll(-1)` or `scroll(2)`.
