### PR TITLE
chore(grunt): adds conventional-changelog task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,6 +119,11 @@ module.exports = function(grunt) {
           singleRun: true
       }
     },
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md'
+      }
+    },
     watch: {
       dev: {
         files: ['<%= dirs.src %>/**'],

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "karma-coffee-preprocessor": "~0.1.2",
     "karma-phantomjs-launcher": "~0.1.1",
     "grunt-karma": "~0.6.2",
-    "karma-coverage": "~0.1.4"
+    "karma-coverage": "~0.1.4",
+    "grunt-conventional-changelog": "~1.0.0"
   },
   "scripts": {
     "test": "karma start test/karma.conf.js --single-run --browsers Chrome",


### PR DESCRIPTION
this is for generating changelogs based on the commit
messages you're already using in the project.

See http://github.com/btford/grunt-conventional-changelog
