### PR TITLE
Fix being on a "not existing" slide when removing elements

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -147,6 +147,7 @@
                                 slidesCount = Object.keys(newValue).length;
                             }
                             updateIndicatorArray();
+                            updateSlidePosition();
                             if (!containerWidth) updateContainerWidth();
                             goToSlide(scope.carouselIndex);
                         });


### PR DESCRIPTION
If your are e.g. on slide 2 and have the elements on that slide removed, you will now automatically switch to the first slide, instead of being on that empty no longer existing second slide.
