### PR TITLE
feat (directive): IE9 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,25 @@ angular.module('MyApp', ['angular-carousel']);
 </ul>
 ```
 
+ 5. Add a `rn-carousel-ie9support` attribute to your `<ul>` block to enable compatibility with the browser Internet Explorer 9. For this to work, you need to instal any requestAnimationFrame polyfill, for example the raf.js module ( "bower install raf.js")
+ 
+ ```html
+<ul rn-carousel rn-carousel-ie9support class="image">
+  <li ng-repeat="image in sportImages" style="background-image:url({{ image }});">
+    <div class="layer">{{ image }}</div>
+  </li>
+</ul>
+```
+
+
 
 ## Features :
  - Mobile friendly, tested on webkit+firefox
- - use CSS 3D transformations and `requestAnimationFrame`.
+ - use CSS 3D transformations and `requestAnimationFrame`. (disabled for IE9)
  - DOM buffering
  - index data-binding
  - optional indicators
+ - optional support for Internet Explorer 9
 
 ### Regular carousel :
  - `rn-carousel-index` two way binding to control the carousel position.

--- a/index.html
+++ b/index.html
@@ -58,6 +58,27 @@
                 <iframe width="100%" height="80%" src="//www.youtube.com/embed/OQSNhk5ICTI" frameborder="0" allowfullscreen></iframe>
             </li>
         </ul>
+        
+        
+        <h3>Enabled I9 Support</h3>
+        <ul rn-carousel rn-carousel-indicator rn-carousel-ie9support class="my-slider standard ng-cloak">
+            <li ng-style="{'background-color': colors[0]}">
+                This is a standard template
+                <div class="big">slide #1</div>
+            </li>
+            <li ng-style="{'background-color': colors[10]}">
+                Here's sophie : <br>
+                <img src="./demo/img/sophie.jpeg">
+            </li>
+            <li ng-style="{'background-color': colors[30]}">
+                A friend of mine : <br>
+                <img src="./demo/img/grumpy.jpg" height="120">
+            </li>
+            <li ng-style="{'background-color': colors[40]}">
+                And to finish :
+                <iframe width="100%" height="80%" src="//www.youtube.com/embed/OQSNhk5ICTI" frameborder="0" allowfullscreen></iframe>
+            </li>
+        </ul>
 
         <h3>Standard carousel with thumbs navigation </h3>
         <div class="details">This one has an initial index and the thumbs controls the rn-carousel-index binding</div>

--- a/src/css/angular-carousel.scss
+++ b/src/css/angular-carousel.scss
@@ -15,6 +15,17 @@ $rn-carousel-control-height: 30px;
     padding: 0;
     margin: 0;
 }
+
+/* IE 9 */
+:root .rn-carousel-slides {
+	transform: translate(0,0);
+	position: relative;
+	white-space: nowrap;
+	overflow: visible;
+	padding: 0;
+	margin: 0;
+}
+
 .rn-carousel-slide {
     white-space: normal;
     vertical-align: top;

--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -191,7 +191,16 @@
                         offset = x;
                         var move = -Math.round(offset);
                         move += (scope.carouselBufferIndex * containerWidth);
-                        carousel[0].style[transformProperty] = 'translate3d(' + move + 'px, 0, 0)';
+
+                        /* Check Internet Explorer 9 Compatibility */       
+                        if( angular.isDefined(iAttributes.rnCarouselIe9support) && 
+                            !(is3dAvailable)
+                        ){
+                            carousel[0].style[transformProperty] = 'translate(' + move + 'px, 0)';
+                        }
+                        else {
+                            carousel[0].style[transformProperty] = 'translate3d(' + move + 'px, 0, 0)';
+                        }
                     }
 
                     function autoScroll() {
@@ -204,6 +213,8 @@
                             delta = amplitude * Math.exp(-elapsed / timeConstant);
                             if (delta > rubberTreshold || delta < -rubberTreshold) {
                                 scroll(destination - delta);
+                                /* We are using raf.js, a requestAnimationFrame polyfill, so
+                                this will work on IE9 */
                                 requestAnimationFrame(autoScroll);
                             } else {
                                 goToSlide(destination / containerWidth);
@@ -305,9 +316,12 @@
                             if (delta > 2 || delta < -2) {
                                 swipeMoved = true;
                                 startX = x;
+
+                                /* We are using raf.js, a requestAnimationFrame polyfill, so
+                                this will work on IE9 */
                                 requestAnimationFrame(function() {
                                     scroll(capPosition(offset + delta));
-                                });
+                                });                                
                             }
                         }
                         return false;
@@ -347,6 +361,8 @@
                         if (forceAnimation) {
                             amplitude = offset - currentOffset;
                         }
+                        /* We are using raf.js, a requestAnimationFrame polyfill, so
+                        this will work on IE9 */
                         requestAnimationFrame(autoScroll);
 
                         return false;
@@ -385,6 +401,35 @@
                         }
                         return true;
                     });
+
+                    //Detect support of translate3d
+                    function has3d(){
+                        var el = document.createElement('p'),
+                        has3d,
+                        transforms = {
+                            'webkitTransform':'-webkit-transform',
+                            'OTransform':'-o-transform',
+                            'msTransform':'-ms-transform',
+                            'MozTransform':'-moz-transform',
+                            'transform':'transform'
+                        };
+                     
+                        // Add it to the body to get the computed style
+                        document.body.insertBefore(el, null);
+                     
+                        for(var t in transforms){
+                            if( el.style[t] !== undefined ){
+                                el.style[t] = 'translate3d(1px,1px,1px)';
+                                has3d = window.getComputedStyle(el).getPropertyValue(transforms[t]);
+                            }
+                        }
+                     
+                        document.body.removeChild(el);
+                     
+                        return (has3d !== undefined && has3d.length > 0 && has3d !== "none");
+                    }
+
+                    var is3dAvailable = has3d();
 
                     function onOrientationChange() {
                         updateContainerWidth();


### PR DESCRIPTION
IE9 support, so the carrousel will work on IE9.
Optional parameter rn-carousel-ie9support will enable this support.
If enabled, the directive will check if the browser is IE9
and, in this case, will use translate instead of translate3d.
For this to work, a RequestAnimationFrame polyfill is needed. You can
install any of your convenience, e.g. 'bower install raf.js'

Version tag: 0.2.0+IE9Support
