### PR TITLE
Fix to "$digest already in progress" error.

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -3,7 +3,7 @@
 
     angular.module('angular-carousel')
 
-    .directive('rnCarousel', ['$swipe', '$window', '$document', '$parse', '$compile', function($swipe, $window, $document, $parse, $compile) {
+    .directive('rnCarousel', ['$swipe', '$window', '$document', '$parse', '$compile', '$rootScope', function($swipe, $window, $document, $parse, $compile, $rootScope) {
         // internal ids to allow multiple instances
         var carouselId = 0,
             // used to compute the sliding speed
@@ -249,7 +249,7 @@
                         updateBufferIndex();
                         // if outside of angular scope, trigger angular digest cycle
                         // use local digest only for perfs if no index bound
-                        if (scope.$$phase!=='$apply' && scope.$$phase!=='$digest') {
+                        if ($rootScope.$$phase!=='$apply' && $rootScope.$$phase!=='$digest') {
                             if (isIndexBound) {
                                 scope.$apply();
                             } else {


### PR DESCRIPTION
When using angular-carousel inside an isolated scope it can happen to get the "$digest already in progress" error. I fixed it by checking $$phase of $rootScope instead of the local scope's.
