### PR TITLE
add support for iOS6 webViews

### DIFF
--- a/dist/angular-carousel.js
+++ b/dist/angular-carousel.js
@@ -73,6 +73,8 @@ angular.module('angular-carousel')
             // in absolute pixels, at which distance the slide stick to the edge on release
             rubberTreshold = 3;
 
+        var requestAnimationFrame = $window.requestAnimationFrame || $window.webkitRequestAnimationFrame;     
+
         return {
             restrict: 'A',
             scope: true,


### PR DESCRIPTION
This seems to fix a bug in the carousel animation on iOS6, tested on an iPhone 4S
