### PR TITLE
feat (directive): IE8 Support

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -166,13 +166,15 @@
                     }
 
                     function getCarouselWidth() {
-                       // container.css('width', 'auto');
+                        // container.css('width', 'auto');
                         var slides = carousel.children();
+                        var rect = {};
                         if (slides.length === 0) {
-                            containerWidth = carousel[0].getBoundingClientRect().width;
+                            rect = carousel[0].getBoundingClientRect();
                         } else {
-                            containerWidth = slides[0].getBoundingClientRect().width;
+                            rect = slides[0].getBoundingClientRect();
                         }
+                        containerWidth = rect.width ? rect.width : rect.right - rect.left;
                         // console.log('getCarouselWidth', containerWidth);
                         return containerWidth;
                     }
@@ -193,10 +195,14 @@
                         var move = -Math.round(offset);
                         move += (scope.carouselBufferIndex * containerWidth);
 
-                        if(!is3dAvailable) {
-                            carousel[0].style[transformProperty] = 'translate(' + move + 'px, 0)';
+                        if (transformProperty !== undefined) {
+                            if (!is3dAvailable) {
+                                carousel[0].style[transformProperty] = 'translate(' + move + 'px, 0)';
+                            } else {
+                                carousel[0].style[transformProperty] = 'translate3d(' + move + 'px, 0, 0)';
+                            }
                         } else {
-                            carousel[0].style[transformProperty] = 'translate3d(' + move + 'px, 0, 0)';
+                            carousel[0].style.marginLeft = move + 'px';
                         }
                     }
 
@@ -389,8 +395,12 @@
                     }
 
                     // detect supported CSS property
-                    transformProperty = 'transform';
-                    ['webkit', 'Moz', 'O', 'ms'].every(function (prefix) {
+                    if (typeof document.body.style['transform'] !== 'undefined') {
+                        transformProperty = 'transform';
+                    } else {
+                        transformProperty = undefined;
+                    }
+                    ['webkit', 'Moz', 'O', 'ms'].every(function(prefix) {
                         var e = prefix + 'Transform';
                         if (typeof document.body.style[e] !== 'undefined') {
                             transformProperty = e;


### PR DESCRIPTION
change getCarouselWidth() to calculate containerWidth
change scroll() to set style.marginLeft if transformProperty is undefined
change transformProperty to undefined if transform style doesn't exist

These were made to a project I've been working on which required IE8 support. I'll be dropping support for IE8 in future projects with AngularJS 1.3 on the horizon, so feel free to reject.
