### PR TITLE
Removed unnecessary vendor prefixes

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -408,9 +408,7 @@
                         has3d,
                         transforms = {
                             'webkitTransform':'-webkit-transform',
-                            'OTransform':'-o-transform',
                             'msTransform':'-ms-transform',
-                            'MozTransform':'-moz-transform',
                             'transform':'transform'
                         };
                         // Add it to the body to get the computed style


### PR DESCRIPTION
The only vendor prefixes that are needed are -webkit and -ms.
http://caniuse.com/#feat=transforms3d
