### PR TITLE
fix (carousel): fallback for browsers which doesn't support requestAnima...

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -15,6 +15,20 @@
 
         var requestAnimationFrame = $window.requestAnimationFrame || $window.webkitRequestAnimationFrame || $window.mozRequestAnimationFrame;
 
+        //fallback for the browers which doesn't support requestAnimationFrame
+        if(requestAnimationFrame == undefined || requestAnimationFrame == null){
+          var animationQueue = [];
+          requestAnimationFrame = function(frameFunc){
+            animationQueue.push(frameFunc);
+          }
+          setInterval(function(){
+            if(animationQueue.length > 0){
+              animationQueue[0]();
+              animationQueue.shift();
+            }
+          },10);
+        }
+
         return {
             restrict: 'A',
             scope: true,


### PR DESCRIPTION
...tionFrame

 Some browsers don't support requestAnimationFrame,
mozRequestAnimationFrame and webkitRequestAnimationFrame(ex: android
2.x)

adds some code for fallback
