### PR TITLE
Allow angular version 1.3+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,10 +16,10 @@
     "demo"
   ],
   "dependencies": {
-    "angular": "~1.2.10",
-    "angular-touch": "~1.2.10"
+    "angular": ">=1.2.10",
+    "angular-touch": ">=1.2.10"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.10"
+    "angular-mocks": ">=1.2.10"
   }
 }


### PR DESCRIPTION
Angular came out with version 1.3.0 and these bower version strings do not respect the minor version change.
