### PR TITLE
Support inner <ul> elements inside slides

### DIFF
--- a/src/css/angular-carousel.scss
+++ b/src/css/angular-carousel.scss
@@ -15,7 +15,7 @@ ul[rn-carousel] {
   perspective:1000px;
   -ms-touch-action: pan-y;
   touch-action: pan-y;
-  li {
+  > li {
     color:black;
     backface-visibility: hidden;
     overflow: visible;
@@ -34,7 +34,7 @@ ul[rn-carousel] {
 }
 
 /* prevent flickering when moving buffer */
-ul[rn-carousel-buffered] li {
+ul[rn-carousel-buffered] > li {
   display:none;
 }
 

--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -205,7 +205,7 @@
                         });
 
                         function getSlidesDOM() {
-                            return iElement[0].querySelectorAll('li');
+                            return iElement[0].querySelectorAll(':scope > li');
                         }
 
                         function documentMouseUpEvent(event) {


### PR DESCRIPTION
AngularJS Touch Carousel should only animate and change CSS properties
on direct `<li>` children. Otherwise slides cannot contain other
`<ul>` elements.
