### PR TITLE
Prevent error when carousel is hidden by ngIf

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -118,7 +118,8 @@
                 scope: true,
                 compile: function(tElement, tAttributes) {
                     // use the compile phase to customize the DOM
-                    var firstChildAttributes = tElement[0].querySelector('li').attributes,
+                    var firstChild = tElement[0].querySelector('li'),
+                        firstChildAttributes = (firstChild) ? firstChild.attributes : [],
                         isRepeatBased = false,
                         isBuffered = false,
                         repeatItem,


### PR DESCRIPTION
When the carousel is hidden by `ngIf` the selector `tElement[0].querySelector('li')` returns `null` causing the following error:

```
TypeError: Cannot read property 'attributes' of null
    at Object.compile (http://localhost:9000/bower_components/angular-carousel/dist/angular-carousel.js:221:79)
    at applyDirectivesToNode (http://localhost:9000/bower_components/angular/angular.js:6473:32)
    at compileNodes (http://localhost:9000/bower_components/angular/angular.js:6043:15)
    at compileNodes (http://localhost:9000/bower_components/angular/angular.js:6055:15)
    at compile (http://localhost:9000/bower_components/angular/angular.js:5976:15)
    at applyDirectivesToNode (http://localhost:9000/bower_components/angular/angular.js:6386:33)
    at compileNodes (http://localhost:9000/bower_components/angular/angular.js:6043:15)
    at compileNodes (http://localhost:9000/bower_components/angular/angular.js:6055:15)
    at compile (http://localhost:9000/bower_components/angular/angular.js:5976:15)
    at link (http://localhost:9000/bower_components/angular-route/angular-route.js:903:18) <ul class="notifications" rn-carousel="" rn-carousel-index="notificationIndex" rn-carousel-buffered="">
```
