### PR TITLE
Fix for #250

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -434,7 +434,6 @@
 
                             scope[deepWatch?'$watch':'$watchCollection'](repeatCollection, function(newValue, oldValue) {
                                 //console.log('repeatCollection', currentSlides);
-                                var oldSlides = (currentSlides || newValue).slice();
                                 currentSlides = newValue;
                                 // if deepWatch ON ,manually compare objects to guess the new position
                                 if (deepWatch && angular.isArray(newValue)) {


### PR DESCRIPTION
As pointed out in #250, in Angular 1.3 this line throws an error. Since `oldSlides` isn't used anywhere I simply deleted it.
