### PR TITLE
Update rn-carousel.js

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -406,7 +406,7 @@
                                 scope.$parent.$watch(indexModel, function(newValue, oldValue) {
 
                                     if (newValue !== undefined && newValue !== null) {
-                                        if (currentSlides && newValue >= currentSlides.length) {
+                                        if (currentSlides && currentSlides.length > 0 && newValue >= currentSlides.length) {
                                             newValue = currentSlides.length - 1;
                                             updateParentIndex(newValue);
                                         } else if (currentSlides && newValue < 0) {


### PR DESCRIPTION
When rn-carousel is initialized slideIndex is overwritten because of not initializing the currentSlides array. 
This fix allow to initialize rn-carousel to a specified index.