### PR TITLE
Added support for carouselTap message to be emitted when slide clicked/tapped

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -481,6 +481,7 @@
                             //  console.log('swipeEnd', 'scope.carouselIndex', scope.carouselIndex);
                             // Prevent clicks on buttons inside slider to trigger "swipeEnd" event on touchend/mouseup
                             if (event && !swipeMoved) {
+                                scope.$emit( 'carouselTap', event.target );
                                 return;
                             }
                             unbindMouseUpEvent();


### PR DESCRIPTION
This commit adds support for a carouselTap message to be emitted when the carousel has an item tapped (as opposed to dragged) - which allows parents to create controls that perform actions on tap (e.g. opening a full-screen viewer).

Within parent scopes (controller/directive/etc) you can:

         $scope.$on('carouselTap', function(event, target){
            console.log('YOU TAPPED!  The item you tapped is:', target );
         });

Those can use the target passed to determine an appropriate action as necessary. 
