### PR TITLE
fix: allow use of data-rn-carousel for valid html

### DIFF
--- a/src/css/angular-carousel.scss
+++ b/src/css/angular-carousel.scss
@@ -2,7 +2,8 @@ input[type=range] {
   width:300px;
 }
 
-ul[rn-carousel] {
+ul[rn-carousel],
+ul[data-rn-carousel] {
   overflow:hidden;
   padding:0;
   white-space: nowrap;
@@ -29,11 +30,13 @@ ul[rn-carousel] {
 }
 
 /* prevent flickering when moving buffer */
-ul[rn-carousel-buffered] > li {
+ul[rn-carousel-buffered],
+ul[data-rn-carousel-buffered] > li {
   display:none;
 }
 
-ul[rn-carousel-transition="hexagon"] {
+ul[rn-carousel-transition="hexagon"],
+ul[data-rn-carousel-transition="hexagon"] {
   overflow:visible;
 }
 

--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -228,7 +228,7 @@
                         }
 
                         function getSlidesDOM() {
-                            return iElement[0].querySelectorAll('ul[rn-carousel] > li');
+                            return iElement[0].querySelectorAll('ul[rn-carousel] > li,ul[data-rn-carousel] > li');
                         }
 
                         function documentMouseUpEvent(event) {


### PR DESCRIPTION
Using customer attributes results in invalid html.  Usually data-directive works but not for this.  This seems to restore that option.

Closes #330