### PR TITLE
Fixes rnCarouselOnInfiniteScrollLeft

### DIFF
--- a/dist/angular-carousel.js
+++ b/dist/angular-carousel.js
@@ -603,7 +603,7 @@ angular.module('angular-carousel').run(['$templateCache', function($templateCach
                                 }
                                 if(iAttributes.rnCarouselOnInfiniteScrollLeft!==undefined && slidesMove === 0 && scope.carouselIndex === 0 && moveOffset === 0) {
                                     $parse(iAttributes.rnCarouselOnInfiniteScrollLeft)(scope)
-                                    goToSlide(currentSlides.length);
+                                    goToSlide(currentSlides.length-1);
                                 }
 
                             } else {


### PR DESCRIPTION
Fixes rnCarouselOnInfiniteScrollLeft making goToSlide() go to currentSlides.lenght-1 instead of just currentSlides.lenght.