### PR TITLE
Added lock to 'goign to prev slide' operation

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -264,7 +264,9 @@
                             if (index < 0) {
                                 index = currentSlides.length - 1;
                             }
-                            goToSlide(index, slideOptions);
+                            if (!locked) {
+                                goToSlide(index, slideOptions);    
+                            }
                         };
 
                         function goToSlide(index, slideOptions) {


### PR DESCRIPTION
Hi people, 

here is a little pull request with the fix of a problem that I found, while I was searching the lib because of a strange behaviour. I noticed that the `scope.prevSlide()` function of the directive `rnCarousel` did not used the locked defined. 
