### PR TITLE
Defect. Disappear all carousel elements.

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -127,6 +127,26 @@
                 rubberTreshold = 3;
 
             var requestAnimationFrame = $window.requestAnimationFrame || $window.webkitRequestAnimationFrame || $window.mozRequestAnimationFrame;
+            
+            var debounce = function(func, wait, immediate) {
+                var timeout;
+                return function() {
+                    var context = this,
+                        args = arguments;
+                    var later = function() {
+                        timeout = null;
+                        if ( !immediate ) {
+                            func.apply(context, args);
+                        }
+                    };
+                    var callNow = immediate && !timeout;
+                    clearTimeout(timeout);
+                    timeout = setTimeout(later, wait || 300);
+                    if ( callNow ) {
+                        func.apply(context, args);
+                    }
+                };
+            };
 
             function getItemIndex(collection, target, defaultIndex) {
                 var result = defaultIndex;
@@ -577,10 +597,10 @@
                             }
                         }
 
-                        function onOrientationChange() {
+                        var onOrientationChange = debounce(function() {
                             updateContainerWidth();
                             goToSlide();
-                        }
+                        });
 
                         // handle orientation change
                         var winEl = angular.element($window);


### PR DESCRIPTION
For some mobile tablets, when we move to last page in portrait mode, which has one element and after that we change orientation to landscape, all elements just disappear (For example: Apple iPad 3, iOS 8.3)
That happened, because some index, scope.carouselIndex do not have time to recalculate.
I added 'debounce' pattern for 'orientationchange' event
( https://css-tricks.com/the-difference-between-throttling-and-debouncing/ )