### PR TITLE
Wait for animation to finish before moving to previous slide

### DIFF
--- a/src/directives/rn-carousel.js
+++ b/src/directives/rn-carousel.js
@@ -264,7 +264,9 @@
                             if (index < 0) {
                                 index = currentSlides.length - 1;
                             }
-                            goToSlide(index, slideOptions);
+                            if (!locked) {
+                                goToSlide(index, slideOptions);
+                            }
                         };
 
                         function goToSlide(index, slideOptions) {


### PR DESCRIPTION
Inline with nextSlide: don't do anything if locked (animation still busy)