### PR TITLE
Fix nested carousels

### DIFF
--- a/dist/angular-carousel.js
+++ b/dist/angular-carousel.js
@@ -307,7 +307,14 @@ angular.module('angular-carousel').run(['$templateCache', function($templateCach
                         }
 
                         function getSlidesDOM() {
-                            return iElement[0].querySelectorAll('ul[rn-carousel] > li');
+                            var nodes = iElement[0].childNodes;
+                            var slides = [];
+                            for(var i=0; i<nodes.length ;i++){
+                              if(nodes[i].tagName === "LI"){
+                                slides.push(nodes[i]);
+                              }
+                            }
+                            return slides;
                         }
 
                         function documentMouseUpEvent(event) {

--- a/dist/angular-carousel.js
+++ b/dist/angular-carousel.js
@@ -310,9 +310,9 @@ angular.module('angular-carousel').run(['$templateCache', function($templateCach
                             var nodes = iElement[0].childNodes;
                             var slides = [];
                             for(var i=0; i<nodes.length ;i++){
-                              if(nodes[i].tagName === "LI"){
-                                slides.push(nodes[i]);
-                              }
+                                if(nodes[i].tagName === "LI"){
+                                    slides.push(nodes[i]);
+                                }
                             }
                             return slides;
                         }


### PR DESCRIPTION
`GetSlidesDOM` was looking all the way down the DOM tree.
If a carousel had others carousels nested in, the GetSlidesDOM was returning an array containing all the slides from both the topmost and the child(ren) carousel(s), causing the topmost slides to have a wrong CSS translation.

The new `GetSlidesDOM` is only looking for slides (nodes with 'LI' tagName) directly under the directive's element, avoiding collision with nested carousels' slides.